### PR TITLE
little interface polishing : add back button + settings button + fix bug on edit profile

### DIFF
--- a/app/(app)/[handle]/page.tsx
+++ b/app/(app)/[handle]/page.tsx
@@ -1,5 +1,6 @@
 import { ProfileHeader } from "@/components/profile/ProfileHeader"
 import { PostList } from "@/components/profile/PostList"
+import { BackButton } from "@/components/ui/BackButton"
 import { auth } from "@/lib/auth"
 import prisma from "@/lib/prisma"
 import { headers } from "next/headers"
@@ -83,6 +84,7 @@ const ProfilePage = async ({ params }: Props) => {
 
     return (
         <div className="max-w-2xl mx-auto py-6 px-4 space-y-6">
+            <BackButton />
             <ProfileHeader
                 user={{ ...profileUser, username: profileUser.username }}
                 isOwnProfile={isOwnProfile}

--- a/app/(app)/feedback/page.tsx
+++ b/app/(app)/feedback/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react"
 import { redirect } from "next/navigation"
 import { headers } from "next/headers"
 import { auth } from "@/lib/auth"
+import { BackButton } from "@/components/ui/BackButton"
 import { FeedbackTabs } from "@/components/feedback/FeedbackTabs"
 import { FeedbackSortSelector } from "@/components/feedback/FeedbackSortSelector"
 import { FeedbackItem } from "@/components/feedback/FeedbackItem"
@@ -61,6 +62,7 @@ const FeedbackPage = async ({ searchParams }: { searchParams: Promise<Record<str
 
     return (
         <div className="max-w-2xl mx-auto py-6 px-4 space-y-6">
+            <BackButton />
             <h1 className="text-2xl font-bold">Feedback</h1>
             <FeedbackFormSection />
             <Separator />

--- a/app/(app)/settings/layout.tsx
+++ b/app/(app)/settings/layout.tsx
@@ -1,8 +1,10 @@
 import { SettingsNav } from "@/components/settings/SettingsNav"
+import { BackButton } from "@/components/ui/BackButton"
 
 const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
     return (
         <div className="max-w-3xl mx-auto px-4 py-8">
+            <BackButton />
             <h1 className="text-2xl font-bold mb-8">Settings</h1>
             <div className="flex flex-col md:flex-row gap-8">
                 <SettingsNav />

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -35,7 +35,9 @@ type Props = {
 
 // Generates initials from a display name (e.g. "John Doe" → "JD")
 const getInitials = (name: string) => {
-    const parts = name.trim().split(/\s+/)
+    const trimmed = name.trim()
+    if (!trimmed) return ''
+    const parts = trimmed.split(/\s+/)
     if (parts.length === 1) return parts[0][0].toUpperCase()
     return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
 }

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -1,12 +1,16 @@
 'use client'
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { Settings } from "lucide-react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Separator } from "@/components/ui/separator"
+import { ShortcutKey } from "@/components/ui/shortcut-key"
 import { FollowButton } from "./FollowButton"
 import { updateProfile } from "@/lib/actions/settings"
 import { toast } from "sonner"
@@ -40,7 +44,26 @@ const joinedDate = (date: Date) =>
     date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
 
 export const ProfileHeader = ({ user, isOwnProfile, isPrivate, followStatus }: Props) => {
+    const router = useRouter()
     const [editing, setEditing] = useState(false)
+
+    // Keyboard shortcut: "s" navigates to settings (own profile only)
+    useEffect(() => {
+        if (!isOwnProfile) return
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key !== 's') return
+            const target = e.target as HTMLElement
+            if (
+                target.tagName === 'INPUT' ||
+                target.tagName === 'TEXTAREA' ||
+                target.isContentEditable
+            ) return
+            e.preventDefault()
+            router.push('/settings')
+        }
+        window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [isOwnProfile, router])
     // local state so the UI reflects changes immediately after save
     const [displayName, setDisplayName] = useState(user.name)
     const [displayBio, setDisplayBio] = useState(user.bio ?? '')
@@ -92,9 +115,18 @@ export const ProfileHeader = ({ user, isOwnProfile, isPrivate, followStatus }: P
                             </Button>
                         </div>
                     ) : (
-                        <Button variant="outline" onClick={() => setEditing(true)}>
-                            Edit profile
-                        </Button>
+                        <div className="flex gap-2">
+                            <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+                                Edit profile
+                            </Button>
+                            <Button variant="outline" size="sm" asChild>
+                                <Link href="/settings">
+                                    <Settings className="size-4" />
+                                    Settings
+                                    <ShortcutKey>S</ShortcutKey>
+                                </Link>
+                            </Button>
+                        </div>
                     )
                 ) : followStatus !== null ? (
                     <FollowButton

--- a/components/profile/__tests__/ProfileHeader.test.tsx
+++ b/components/profile/__tests__/ProfileHeader.test.tsx
@@ -1,0 +1,54 @@
+/// <reference types="vitest/globals" />
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import { ProfileHeader } from '../ProfileHeader'
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/lib/actions/settings', () => ({
+    updateProfile: vi.fn(),
+}))
+
+vi.mock('../FollowButton', () => ({
+    FollowButton: () => null,
+}))
+
+// sonner toast is used in the component but irrelevant for this test
+vi.mock('sonner', () => ({
+    toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() },
+}))
+
+const mockUser = {
+    id: '1',
+    name: 'John Doe',
+    username: 'johndoe',
+    bio: null,
+    image: null,
+    createdAt: new Date('2024-01-01'),
+    _count: { posts: 0, followers: 0, following: 0 },
+}
+
+describe('ProfileHeader', () => {
+    it('does not crash when the name field is fully cleared in edit mode', () => {
+        render(
+            <ProfileHeader
+                user={mockUser}
+                isOwnProfile={true}
+                isPrivate={false}
+                followStatus={null}
+            />
+        )
+
+        // Enter edit mode
+        fireEvent.click(screen.getByText('Edit profile'))
+
+        // Clear the name — triggers getInitials("") which crashes on parts[0][0]
+        const nameInput = screen.getByPlaceholderText('Your name')
+        fireEvent.change(nameInput, { target: { value: '' } })
+
+        // Component should still be mounted and the input visible
+        expect(nameInput).toBeTruthy()
+    })
+})

--- a/components/ui/BackButton.tsx
+++ b/components/ui/BackButton.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useRouter } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export const BackButton = () => {
+    const router = useRouter()
+    return (
+        <Button variant="ghost" size="sm" onClick={() => router.back()} className="-ml-2">
+            <ArrowLeft className="size-4" />
+            Back
+        </Button>
+    )
+}


### PR DESCRIPTION
#### back button
- created backbutton component
- add back button in:
  - profile page
  - feedback page
  - settings layout
#### bug on edit profile
- issue: when editing the profile and the field name was emptied, the profile was crashing
- reason: the initials in the avatar are generated in real time when we edit the name in the field. when there is no string to handle in the name field, it was trying to access an empty string [0], causing a crash
- fix: added an early return for empty/white space only input
#### setting button
- add settings button on profile
- add keyboard shortcut